### PR TITLE
fix blog gitLink generation

### DIFF
--- a/scripts/blog/update-blog-yaml.js
+++ b/scripts/blog/update-blog-yaml.js
@@ -32,7 +32,7 @@ module.exports = function updateFileContents(filePath, callBack) {
     //   item.authorsData = authorsData
     // }
 
-    item.gitLink = filename.split('blog')[1]
+    item.gitLink = `/${path.parse(filename).base}`
     if (item.date) {
       item.date = formatDate(item.date)
     } else {


### PR DESCRIPTION
fixes #68. Using path.parse().base instead of splitting the filename based on the word blog.  

This will prevent posts with the word "blog" in the title from having the incorrect gitLink generated.