### PR TITLE
Fix minor text issue

### DIFF
--- a/src/pages/Success/index.js
+++ b/src/pages/Success/index.js
@@ -66,7 +66,7 @@ export default class Welcome extends Component {
             </div>
           </div>
           <div className={styles.nextSteps}>
-            <h3>New to serverless? Here are next Steps</h3>
+            <h3>New to Serverless? Here are the next steps...</h3>
             <div className={styles.boxWrapper}>
               <div className={styles.box}>
                 <a href='/framework/docs/'>


### PR DESCRIPTION
After logging in from the CLI (v1.14.0), the browser redirects to the `https://serverless.com/success/` page. 

In the message "New to serverless? Here are next Steps", should be "New to Serverless? Here are the next steps...".