### PR TITLE
add temporary redirect to the platform docs

### DIFF
--- a/src/_redirects
+++ b/src/_redirects
@@ -38,6 +38,7 @@
 /framework/docs/cli-reference/slstats/ /framework/docs/providers/aws/cli-reference/slstats 301
 /framework/docs/providers/aws/setup/ /framework/docs/providers/aws/guide/credentials 301
 /framework/docs/aws/ /framework/docs/providers/aws 301
+/platform/docs/ /framework/docs/platform 302
 /jobs/ /company/jobs/ 301
 /framework/docs/docs/workflow /framework/docs/providers/aws/guide/workflow/ 301
 /blog/challenge-accepted-building-a-better-australian-census-site-with-serverless-architecture/ /blog/building-a-better-australian-census-site/ 301


### PR DESCRIPTION
In the future the platform documentation will live under `/platform/docs/`. In order to share the link even today @brianneisler asked me to add this redirect.