### PR TITLE
Change text font to Gibson for Docs and Blog

### DIFF
--- a/src/index.global.css
+++ b/src/index.global.css
@@ -147,7 +147,6 @@ tr:nth-child(even) {
 th, td {
   text-align: left;
   padding: 10px;
-  font-weight: 300;
 }
 td ul {
   margin: 0;

--- a/src/layouts/Default/Default.css
+++ b/src/layouts/Default/Default.css
@@ -4,6 +4,12 @@
 .page {
   max-width: 96rem;
   margin: 8rem auto 0 auto;
+  font-family: Gibson, Avenir, sans-serif;
+  line-height: 1.6;
+
+  h1, h2, h3, h4, strong {
+    font-family: Avenir, Gibson, sans-serif;
+  }
   img {
     max-width: 100%;
   }


### PR DESCRIPTION
Use of Gibson as content font family for Docs and Blog.