### PR TITLE
Overflow of developer menu items in Navbar - Chrome on Windows 10

### DIFF
--- a/src/fragments/Header/Header.css
+++ b/src/fragments/Header/Header.css
@@ -248,7 +248,7 @@ ul.mainNav{
         display: block;
 
         > a{
-          display: block;
+          display: inline-block;
           color: $grey2_serverless;
           font-family: 'Serverless';
           font-size: 1.1em;


### PR DESCRIPTION
### This PR contains,

* The width of sub-menu items under 'developers' menu on Navbar is overflowing the parent section. It provides bad UX in Chrome running on windows 10.