### PR TITLE
Modify slack links to open in new tabs

### DIFF
--- a/src/fragments/Footer/index.js
+++ b/src/fragments/Footer/index.js
@@ -153,7 +153,7 @@ export default class Footer extends Component {
                       <Link to='/community/meetups/'>meetups</Link>
                     </li>
                     <li>
-                      <a href='/slack'>slack</a>
+                      <a href='/slack/' target='_blank'>slack</a>
                     </li>
                     <li>
                       <Link to='/workshops/'>workshops</Link>

--- a/src/fragments/Header/index.js
+++ b/src/fragments/Header/index.js
@@ -153,7 +153,7 @@ export default class Header extends Component {
                       <li><Link to='/blog' onClick={this.navClicked}>blog</Link></li>
                       <li><a href='https://forum.serverless.com' target='_blank'>forum</a></li>
                       <li><Link to='/community/meetups' onClick={this.navClicked}>meetups</Link></li>
-                      <li><a href='/slack'>slack</a></li>
+                      <li><a href='/slack/' target='_blank'>slack</a></li>
                       <li><Link to='/workshops' onClick={this.navClicked}>workshops</Link></li>
                     </ul>
                   </div>


### PR DESCRIPTION
This PR modifies the slack links to open up in new tabs instead of redirecting the current page.