### PR TITLE
Recover workshop pages (ref: SITE-353)

### DIFF
--- a/dynamic-content-generator/page/workshop.js
+++ b/dynamic-content-generator/page/workshop.js
@@ -1,5 +1,5 @@
 const { getFileFromProjectRoot } = require('./utils')
-const workshops = getFileFromProjectRoot('src/constants/workshops.json')
+const workshops = require(getFileFromProjectRoot('src/constants/workshops.json'))
 
 const pageCreator = (createPage) => (
   new Promise((resolve, reject) => {

--- a/src/components/Header/Navbar/Menu/DropdownList/Resource.js
+++ b/src/components/Header/Navbar/Menu/DropdownList/Resource.js
@@ -61,6 +61,17 @@ const Resource = () => (
         slack
       </SubMenuItem>
     </ListItem.noStyleType>
+    <ListItem.noStyleType>
+      <SubMenuItem
+        navProps={{
+          to: resources.workshops,
+          backgroundOnHover: true,
+          completed: true,
+        }}
+      >
+        workshops
+      </SubMenuItem>
+    </ListItem.noStyleType>
   </List>
 )
 


### PR DESCRIPTION
Fix for the following: https://github.com/serverless/site/issues/353

+ [workshops] menu item added back in the 'resources' dropdown