### PR TITLE
Examples Explorer - shippable v1 updates

### DIFF
--- a/dynamic-content-generator/page/example.js
+++ b/dynamic-content-generator/page/example.js
@@ -15,7 +15,7 @@ const graphqlQuery = `
 const createExamplePages = (createPage, examples) => {
     examples.forEach(({ node }, index, records) => {
     createPage({
-      path: `example/${node.id}`,
+      path: `examples/${node.id}`,
       component: getFileFromProjectRoot(`src/templates/example.js`),
       context: {
         exampleId: node.id

--- a/scripts/example/update-example-content.js
+++ b/scripts/example/update-example-content.js
@@ -88,25 +88,30 @@ function fixYamlContent(content, filename) {
     return fixedContent
 }
 
-function getPlatformFullName(platform) {
-    let platformFullName
-
+function makePlatformSEOName(title, platform) {
+    let platformSEOName
+    let appendExample = title.includes('Example') ? '' : ' Example'
     switch (platform) {
         case 'AWS':
-            platformFullName = 'AWS Lambda'
+            platformSEOName = `AWS Lambda Function${appendExample}`
             break
         case 'Google Cloud':
-            platformFullName = 'Google Cloud Functions'
+            platformSEOName = `Google Cloud Functions${appendExample}`
             break
         case 'Azure':
-            platformFullName = 'Azure Functions'
+            platformSEOName = `Azure Functions${appendExample}`
             break
         default:
-            platformFullName = platform
+            platformSEOName = `${platform} Function${appendExample}`
             break
     }
 
-    return platformFullName
+    return platformSEOName
+}
+
+function makeSEOTitle(title, platformSEOName, language) {
+    let seoTitle = `${title} | ${platformSEOName} in ${language}`
+    return seoTitle
 }
 
 module.exports = function updateExamplesContent(examplesDirectoryPath) {
@@ -119,7 +124,8 @@ module.exports = function updateExamplesContent(examplesDirectoryPath) {
             const item = matter(fixedContent).data 
             item.gitLink = makeGitLink(folderName)
             item.title = makeTitle(folderName)
-            item.platformFullName = getPlatformFullName(item.platform)
+            item.platformSEOName = makePlatformSEOName(item.title, item.platform)
+            item.seoTitle = makeSEOTitle(item.title, item.platformSEOName, item.language)
             if (isFileFeatured(folderName)) {
                 item.highlighted = true
             }

--- a/scripts/example/update-example-content.js
+++ b/scripts/example/update-example-content.js
@@ -16,7 +16,7 @@ function isFileFeatured(folderName) {
 }
 
 function makeGitLink(folderName) {
-    return `https://github.com/serverless/examples/tree/master/${folderName}/README.md` //TODO: in config file
+    return `https://github.com/serverless/examples/tree/master/${folderName}` //TODO: in config file
 }
 
 function makeTitle(folderName) {

--- a/src/components/pages/example/EditOnGithub.js
+++ b/src/components/pages/example/EditOnGithub.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Position, Absolute, Button, Fixed, Box } from 'serverless-design-system'
+import { Position, Absolute, Button } from 'serverless-design-system'
 
 const EditGithubButton = styled(Button)`
 line-height: 14px;
@@ -11,11 +11,6 @@ line-height: 14px;
 `
 
 export default class EditOnGithubOption extends React.Component {
-  scrollIntoNewsLetter = () => {
-    const newsletterField =  document.getElementById('newsletter-box')
-    newsletterField.scrollIntoView()
-  }
-
   render() {
     return (
         <Position
@@ -31,16 +26,22 @@ export default class EditOnGithubOption extends React.Component {
             transformOrigin: '100% 0'
           }}
         >
+        <a
+          title='View this example on GitHub'
+          rel='noopener noreferrer'
+          target='_blank'
+          href={this.props.gitLink}
+        >
           <EditGithubButton
             height={32}
             width={161}
             fontSize={'14px'}
             letterSpacing={'0.6px'}
             py={1}
-            onClick={this.scrollIntoNewsLetter}
           >
-            edit on Github
+            view on Github
           </EditGithubButton>
+         </a>
         </Absolute>
       </Position>
     )

--- a/src/components/pages/example/ExampleContent.js
+++ b/src/components/pages/example/ExampleContent.js
@@ -38,12 +38,12 @@ const WidthContainer = styled(Box)`
 `
 
 //TODO - REFACTOR THIS (components)
-export default ({ id, frontmatter, content, location }) => {
+export default ({ frontmatter, content }) => {
   return (
         
       <Box
         my={[104, 104, 170]}>
-        <EditOnGithubOption />
+        <EditOnGithubOption gitLink={frontmatter.gitLink}/>
         <AppContainer>
             <ExampleBreadcrumbs path={`/examples/`}/>
             <WidthContainer>
@@ -72,9 +72,16 @@ export default ({ id, frontmatter, content, location }) => {
             />
             <WidthContainer>
             <Row justifyContent='space-between' mt={76} mx='auto'>
-                      <Button height='50px' fontSize='2rem' letterSpacing={'0.8px'} p={0} lineHeight={['14px']}> 
-                    edit on Github
+                <a
+                    title='View this example on GitHub'
+                    rel='noopener noreferrer'
+                    target='_blank'
+                    href={frontmatter.gitLink}
+                    >
+                 <Button height='50px' fontSize='2rem' letterSpacing={'0.8px'} p={0} lineHeight={['14px']}> 
+                    view on Github
                 </Button>
+                </a>
                       <P fontSize='14px' lineHeight={'1.57'} letterSpacing={'0.6px'} color='#000000' opacity='0.4' fontFamily='Serverless'>
                 Latest commit b2f54ec  on Sep 24, 2017
                 </P>

--- a/src/templates/example.js
+++ b/src/templates/example.js
@@ -6,7 +6,7 @@ import { NewToServerlessPrefooterNew as NewToServerlessPrefooter } from 'src/fra
 
 export default ({ data }) => (
   <DefaultLayout prefooter={NewToServerlessPrefooter} footerBackground={false}>
-   <Helmet {...data.Example.frontmatter }/>
+   <Helmet title={data.Example.frontmatter.seoTitle} description={data.Example.frontmatter.description}/>
    <ExampleContent {...data.Example }/>
   </DefaultLayout>
 )
@@ -24,6 +24,7 @@ export const query = graphql`
         authorName
         authorAvatar
         gitLink
+        seoTitle
       }
       content
     }

--- a/src/utils/example.js
+++ b/src/utils/example.js
@@ -1,4 +1,4 @@
-const getExampleLink = (id) => `/example/${id}`
+const getExampleLink = (id) => `/examples/${id}`
 
 export {
     getExampleLink


### PR DESCRIPTION
Following changes were made to the individual example pages:
1 - URL parent directory is /examples/ instead of /example/
2 - SEO title + description pattern that was discussed has been added
3 - 'view on Github' buttons take the user the appropriate repo