### PR TITLE
build docs for current release

### DIFF
--- a/scripts/docs/config.js
+++ b/scripts/docs/config.js
@@ -3,9 +3,9 @@
 */
 const path = require('path')
 const projectRoot = path.join(__dirname, '..', '..')
-const repoURL = 'https://github.com/pdaryani/serverless' //TODO: revert to serverless/serverless
-// set branch of docs you want to see
-const repoBranch = 'doc-build-error-fix' //TODO: revert to master
+const repoURL = 'https://github.com/serverless/serverless'
+// set branch of docs you want to see (set to tag of latest release)
+const repoBranch = 'v1.32.0'
 /* uncomment out the line below to work locally with different docs branch
 repoBranch = 'improve-docs'
 /**/


### PR DESCRIPTION
1st, switched back to main repo for docs instead of fork.
2nd, building the latest released tag instead of master. This is
a good idea because it will avoid us getting issues like
serverless/serverless#5479