### PR TITLE
blog anchor fix

### DIFF
--- a/dynamic-content-generator/node.js
+++ b/dynamic-content-generator/node.js
@@ -126,6 +126,7 @@ const sourceBlogs = (createNode) => (err, content, filename, next) => {
 
   unified().
     use(markdown).
+    use(slug).
     use(highlight).
     use(html).
     process(markdownContent, (err, file) => {


### PR DESCRIPTION
this PR contains a fix for anchor link tags that don't work in the blog section atm: https://serverless.com/blog/no-server-november-challenge/#rules
