### PR TITLE
Quick fix for making links on blogs more easily clickable.

### DIFF
--- a/src/components/pages/blog/BlogContent/ShareOptions.js
+++ b/src/components/pages/blog/BlogContent/ShareOptions.js
@@ -51,7 +51,7 @@ export default class ShareOptions extends React.Component {
       <Position
         position='sticky'
         top='40%'
-        height={20}
+        height={0}
         width={1}
       >
         <Absolute


### PR DESCRIPTION
I was learning serverless today (it's awesome by the way), and found that several links weren't clickable in the blog.

It looks like the social share widget's height was blocking links for me.

This fixes it.