### PR TITLE
Update meetup group for Minnesota

### DIFF
--- a/src/components/pages/resources/events/ServerlessUserGroups/index.js
+++ b/src/components/pages/resources/events/ServerlessUserGroups/index.js
@@ -38,9 +38,9 @@ const items = [
     link: 'https://meetup.com/Serverless-Atlanta',
   },
   {
-    title: 'Serverless Minneapolis',
-    location: 'Minneapolis',
-    link: 'https://meetup.com/Serverless-Minneapolis',
+    title: 'Serverless MN',
+    location: 'Minneapolis/St Paul',
+    link: 'https://meetup.com/Serverless-MN',
   },
   {
     title: 'Serverless LA',


### PR DESCRIPTION
Serverless Minneapolis hasn't met for years, Serverless MN is the new meetup https://meetup.com/Serverless-MN