### PR TITLE
Improve project meta data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "Serverless",
+  "name": "@serverless/site",
+  "private": true,
   "description": "Serverless Website",
   "version": "1.0.0",
   "dependencies": {


### PR DESCRIPTION
- Name `Serverless` is vague, also does not comply to the [naming rules](https://docs.npmjs.com/files/package.json#name) (e.g. VS Code raises a warning when I edit the file).
For packages not intended to be published `name` field can be omitted, but that is likely to raise issues (e.g. after deploy, gatsby will say `You can now view undefined in the browser.`). So I think it's good to have it
- [`private: true`](https://docs.npmjs.com/files/package.json#private) makes clear signal it's not intended for publishing, and prevents accidental publish.
