### PR TITLE
Move hover grid more towards the hovered item

### DIFF
--- a/src/components/NavLink/index.js
+++ b/src/components/NavLink/index.js
@@ -18,8 +18,8 @@ const getLinkStyle = ({ backgroundOnHover }) => `
           width: 25px;
           height: 20px;
           position: absolute;
-          left: -10px;
-          top: -5px;
+          top: 1.5em;
+          left: -2em;
           background: url(${dotGridBacground});
           background-size: cover;
           display: none;


### PR DESCRIPTION
I included screenshots of the prior styling as opposed to the update

Before:
![serverless-before](https://user-images.githubusercontent.com/8659099/65778223-8ac05700-e113-11e9-9846-a7b07f245b38.png)

After:
![serverless-after](https://user-images.githubusercontent.com/8659099/65778222-8ac05700-e113-11e9-968c-a73842a6f598.png)

This was confirmed an issue on both Chrome and Firefox in the mobile view.