### PR TITLE
Add section on "optimized for serverless workflows"

### DIFF
--- a/src/components/pages/cicd/Optimized/index.js
+++ b/src/components/pages/cicd/Optimized/index.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Flex } from 'serverless-design-system'
+import { Heading, P } from 'src/fragments/DesignSystem'
+import { InternalLink } from 'src/fragments'
+import { plugins, cli, components } from 'src/constants/urls'
+
+const Optimized = props => (
+  <Flex
+    flexDirection='column'
+    mx='auto'
+    width={[1, 1, 0.8, 0.8, '80%']}
+    pb={[92, 92, 92, 92, 132]}
+  >
+    <Heading.h3 align={['left', 'left', 'center']}>
+      Optimized for Serverless Workflows
+    </Heading.h3>
+
+    <P>
+      Serverless CI/CD is a new type of testing and deployment automation service laser focused on Serverless Framework
+      development workflows. It is easily configured using concepts familiar to Serverless Framework developers like
+      NPM package scripts, variables, and stages. Preview deployments, promotions and rollbacks are handled using the
+      gitflow you already know and love.
+    </P>
+
+  </Flex>
+)
+
+export default Optimized

--- a/src/components/pages/cicd/WorkflowGuide/Content.js
+++ b/src/components/pages/cicd/WorkflowGuide/Content.js
@@ -5,7 +5,7 @@ import { InternalLink } from 'src/fragments'
 import styles from '../CICD.module.css'
 
 const WorkflowGuideContent = props => (
-  <Flex flexDirection='column' style={{backgroundColor: '#FFF', padding: "20px 50px 50px 50px", borderRadius: 4, boxShadow:"2px 30px 50px 9 rgba(0,0,0,0.1)"}}>
+  <Flex flexDirection='column' style={{backgroundColor: '#FFF', padding: "20px 50px 50px 50px", marginBottom: 80, borderRadius: 4, boxShadow:"2px 30px 50px 9 rgba(0,0,0,0.1)"}}>
     <Heading.h3 align={['left', 'left', 'center']}>
       Serverless CI/CD Workflow Guide
     </Heading.h3>

--- a/src/pages/cicd.js
+++ b/src/pages/cicd.js
@@ -11,6 +11,7 @@ import SecurityBuiltIn from '../components/pages/cicd/SecurityBuiltIn'
 import EasySetup from '../components/pages/cicd/EasySetup'
 import WorkflowGuide from '../components/pages/cicd/WorkflowGuide'
 import FAQ from '../components/pages/cicd/FAQ'
+import Optimized from '../components/pages/cicd/Optimized'
 
 const CiCd = ({ location }) => (
   <HomeLayout prefooter={NewToServerlessPrefooter} transparentHeader={true}>
@@ -21,6 +22,7 @@ const CiCd = ({ location }) => (
     <Hero />
     <Background background={'#f7f7f7'}>
       <AppContainer>
+        <Optimized />
         <EasySetup/>
         <PreviewDeploys/>
         <SecurityBuiltIn/>


### PR DESCRIPTION
Adds a section to the CI/CD landing page (/cicd) called "Optimized for Serverless Workflows".

I'm adding this to better position our CI/CD service as an optimized workflow which can't easily be reproduced using generic CI/CD services. Feedback on this approach and copy is welcome.

I'm making this a draft PR as I'm not happy with the copy yet, but wanted to get feedback early anyway.